### PR TITLE
MAINT: fix validation against test_example.ort

### DIFF
--- a/metadata_schema/header_schema.py
+++ b/metadata_schema/header_schema.py
@@ -1,0 +1,156 @@
+"""
+Generates the schema for an ORSO file.
+
+Author: Brian Maranville (NIST)
+"""
+import datetime
+import enum
+from typing import Optional, Union, List, Literal, Dict, Any
+from dataclasses import field
+
+GENERATE_SCHEMA = True
+
+
+def d(t):
+    return field(metadata={"description": t})
+
+
+if GENERATE_SCHEMA:
+    from pydantic.dataclasses import dataclass as _dataclass
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema: Dict[str, Any]) -> None:
+            for prop in schema.get('properties', {}).values():
+                prop.pop('title', None)
+
+    dataclass = _dataclass(config=Config)
+else:
+    from dataclasses import dataclass
+
+
+@dataclass
+class Creator:
+    name: str
+    affiliation: str
+    time: datetime.datetime = d(
+        "timestamp string, formatted as ISO 8601 datetime")
+    computer: str
+
+
+@dataclass
+class owner:
+    name: str
+    affiliation: str
+    contact: str
+
+
+@dataclass
+class Sample:
+    name: str
+
+
+@dataclass
+class Experiment:
+    instrument: str
+    probe: Union[Literal['neutrons', 'x-rays']]
+    facility: Optional[str] = None
+    ID: Optional[str] = None
+    date: Optional[datetime.datetime] = field(metadata={
+                                              "description": "timestamp string, formatted as ISO 8601 datetime"}, default=None)
+    title: Optional[str] = None
+
+
+class Polarisation(str, enum.Enum):
+    """ The first symbol indicates the magnetisation direction of the incident beam.
+    An optional second symbol indicates the direction of the scattered beam, if a spin analyser is present."""
+    p = '+'
+    m = '-'
+    mm = '--'
+    mp = '-+'
+    pm = '+-'
+    pp = '++'
+
+
+@dataclass
+class data_file:
+    file: str
+    created: datetime.datetime
+
+
+@dataclass
+class Value:
+    magnitude: Union[float, List[float]]
+    unit: str = field(metadata={
+        "description": "SI unit string"})
+
+
+@dataclass
+class ValueRange:
+    min: float
+    max: float
+    unit: str = field(metadata={
+        "description": "SI unit string"})
+    steps: Optional[int] = None
+
+
+@dataclass
+class instrument_settings:
+    incident_angle: Union[Value, ValueRange]
+    wavelength: Union[Value, ValueRange]
+    polarisation: Optional[Polarisation] = None
+
+
+@dataclass
+class Measurement:
+    scheme: Union[Literal["angle- and energy-dispersive",
+                          "angle-dispersive",
+                          "energy-dispersive"]]
+    instrument_settings: instrument_settings
+    data_files: List[data_file]
+
+
+@dataclass
+class Reduction:
+    software: str
+    call: str
+
+
+@dataclass
+class DataSource:
+    owner: owner
+    experiment: Experiment
+    sample: Sample
+    measurement: Measurement
+
+
+@dataclass
+class column:
+    """
+    Information on a data column.
+    """
+
+    name: str = d("The name of the column")
+    dimension: str
+    unit: Optional[Literal["1/angstrom","1/nm"]] = field(default=None, metadata={
+                                "description": "SI unit string"})
+    #description: Optional[str] = field(
+    #    default=None, metadata={"description": "A description of the column"})
+
+
+@dataclass
+class ORSOHeader:
+    creator: Creator
+    data_source: DataSource
+    columns: List[column]
+    reduction: Optional[Reduction] = None
+
+
+if GENERATE_SCHEMA:
+    schema = ORSOHeader.__pydantic_model__.schema()
+    print(schema)
+    import json
+    open("refl_header.schema.json", 'wt').write(json.dumps(schema, indent=2))
+
+    import yaml
+    open("refl_header.schema.yaml", 'w').write(yaml.dump(schema))

--- a/metadata_schema/reduced_data_header_schema.json
+++ b/metadata_schema/reduced_data_header_schema.json
@@ -7,11 +7,24 @@
     },
     "data_source": {
       "$ref": "#/definitions/DataSource"
+    },
+    "reduction": {
+      "$ref": "#/definitions/Reduction"
+    },
+    "columns": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/column"
+      }
+    },
+    "data_set": {
+      "type": "string"
     }
   },
   "required": [
     "creator",
-    "data_source"
+    "data_source",
+    "columns"
   ],
   "definitions": {
     "Creator": {
@@ -96,7 +109,7 @@
         "probe": {
           "enum": [
             "neutrons",
-            "xray"
+            "x-rays"
           ],
           "type": "string"
         }
@@ -170,6 +183,50 @@
       ],
       "type": "string"
     },
+    "data_file": {
+      "type": "object",
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "file",
+        "created"
+      ]
+    },
+    "column": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "unit": {
+          "type": "string",
+          "enum": [
+            "1/angstrom",
+            "1/nm"
+          ]
+        },
+        "dimension": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "dimension"
+      ]
+    },
+    "data_files": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/data_file"
+      }
+    },
     "instrument_settings": {
       "title": "instrument_settings",
       "type": "object",
@@ -217,11 +274,31 @@
         },
         "instrument_settings": {
           "$ref": "#/definitions/instrument_settings"
+        },
+        "data_files": {
+          "$ref": "#/definitions/data_files"
         }
       },
       "required": [
         "scheme",
-        "instrument_settings"
+        "instrument_settings",
+        "data_files"
+      ]
+    },
+    "Reduction": {
+      "title": "Reduction",
+      "type": "object",
+      "properties": {
+        "software": {
+          "type": "string"
+        },
+        "call": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "software",
+        "call"
       ]
     },
     "DataSource": {

--- a/metadata_schema/reduced_data_header_schema.json
+++ b/metadata_schema/reduced_data_header_schema.json
@@ -8,17 +8,14 @@
     "data_source": {
       "$ref": "#/definitions/DataSource"
     },
-    "reduction": {
-      "$ref": "#/definitions/Reduction"
-    },
     "columns": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/column"
       }
     },
-    "data_set": {
-      "type": "string"
+    "reduction": {
+      "$ref": "#/definitions/Reduction"
     }
   },
   "required": [
@@ -53,18 +50,6 @@
         "computer"
       ]
     },
-    "Sample": {
-      "title": "Sample",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "name"
-      ]
-    },
     "owner": {
       "title": "owner",
       "type": "object",
@@ -89,13 +74,20 @@
       "title": "Experiment",
       "type": "object",
       "properties": {
+        "instrument": {
+          "type": "string"
+        },
+        "probe": {
+          "enum": [
+            "neutrons",
+            "x-rays"
+          ],
+          "type": "string"
+        },
         "facility": {
           "type": "string"
         },
         "ID": {
-          "type": "string"
-        },
-        "instrument": {
           "type": "string"
         },
         "date": {
@@ -105,18 +97,23 @@
         },
         "title": {
           "type": "string"
-        },
-        "probe": {
-          "enum": [
-            "neutrons",
-            "x-rays"
-          ],
-          "type": "string"
         }
       },
       "required": [
         "instrument",
         "probe"
+      ]
+    },
+    "Sample": {
+      "title": "Sample",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
       ]
     },
     "Value": {
@@ -142,8 +139,8 @@
         }
       },
       "required": [
-        "unit",
-        "magnitude"
+        "magnitude",
+        "unit"
       ]
     },
     "ValueRange": {
@@ -156,18 +153,18 @@
         "max": {
           "type": "number"
         },
-        "steps": {
-          "type": "integer"
-        },
         "unit": {
           "description": "SI unit string",
           "type": "string"
+        },
+        "steps": {
+          "type": "integer"
         }
       },
       "required": [
-        "unit",
         "min",
-        "max"
+        "max",
+        "unit"
       ]
     },
     "Polarisation": {
@@ -183,56 +180,11 @@
       ],
       "type": "string"
     },
-    "data_file": {
-      "type": "object",
-      "properties": {
-        "file": {
-          "type": "string"
-        },
-        "created": {
-          "type": "string",
-          "format": "date-time"
-        }
-      },
-      "required": [
-        "file",
-        "created"
-      ]
-    },
-    "column": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "unit": {
-          "type": "string",
-          "enum": [
-            "1/angstrom",
-            "1/nm"
-          ]
-        },
-        "dimension": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "name",
-        "dimension"
-      ]
-    },
-    "data_files": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/data_file"
-      }
-    },
     "instrument_settings": {
       "title": "instrument_settings",
       "type": "object",
       "properties": {
         "incident_angle": {
-          "description": "probe angle of incidence",
           "anyOf": [
             {
               "$ref": "#/definitions/Value"
@@ -261,6 +213,23 @@
         "wavelength"
       ]
     },
+    "data_file": {
+      "title": "data_file",
+      "type": "object",
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "file",
+        "created"
+      ]
+    },
     "Measurement": {
       "title": "Measurement",
       "type": "object",
@@ -270,35 +239,23 @@
             "angle- and energy-dispersive",
             "angle-dispersive",
             "energy-dispersive"
-          ]
+          ],
+          "type": "string"
         },
         "instrument_settings": {
           "$ref": "#/definitions/instrument_settings"
         },
         "data_files": {
-          "$ref": "#/definitions/data_files"
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/data_file"
+          }
         }
       },
       "required": [
         "scheme",
         "instrument_settings",
         "data_files"
-      ]
-    },
-    "Reduction": {
-      "title": "Reduction",
-      "type": "object",
-      "properties": {
-        "software": {
-          "type": "string"
-        },
-        "call": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "software",
-        "call"
       ]
     },
     "DataSource": {
@@ -323,6 +280,48 @@
         "experiment",
         "sample",
         "measurement"
+      ]
+    },
+    "column": {
+      "title": "column",
+      "description": "Information on a data column.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the column",
+          "type": "string"
+        },
+        "dimension": {
+          "type": "string"
+        },
+        "unit": {
+          "description": "SI unit string",
+          "enum": [
+            "1/angstrom",
+            "1/nm"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "dimension"
+      ]
+    },
+    "Reduction": {
+      "title": "Reduction",
+      "type": "object",
+      "properties": {
+        "software": {
+          "type": "string"
+        },
+        "call": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "software",
+        "call"
       ]
     }
   }

--- a/metadata_schema/reduced_data_header_schema.json
+++ b/metadata_schema/reduced_data_header_schema.json
@@ -29,7 +29,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "system": {
+        "computer": {
           "type": "string"
         }
       },
@@ -37,7 +37,7 @@
         "name",
         "affiliation",
         "time",
-        "system"
+        "computer"
       ]
     },
     "Sample": {
@@ -52,28 +52,58 @@
         "name"
       ]
     },
+    "owner": {
+      "title": "owner",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "affiliation": {
+          "type": "string"
+        },
+        "contact": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "affiliation",
+        "contact"
+      ]
+    },
     "Experiment": {
       "title": "Experiment",
       "type": "object",
       "properties": {
+        "facility": {
+          "type": "string"
+        },
+        "ID": {
+          "type": "string"
+        },
         "instrument": {
+          "type": "string"
+        },
+        "date": {
+          "description": "timestamp string, formatted as ISO 8601 datetime",
+          "type": "string",
+          "format": "date-time"
+        },
+        "title": {
           "type": "string"
         },
         "probe": {
           "enum": [
-            "neutron",
+            "neutrons",
             "xray"
           ],
           "type": "string"
-        },
-        "sample": {
-          "$ref": "#/definitions/Sample"
         }
       },
       "required": [
         "instrument",
-        "probe",
-        "sample"
+        "probe"
       ]
     },
     "Value": {
@@ -99,6 +129,7 @@
         }
       },
       "required": [
+        "unit",
         "magnitude"
       ]
     },
@@ -121,6 +152,7 @@
         }
       },
       "required": [
+        "unit",
         "min",
         "max"
       ]
@@ -138,14 +170,11 @@
       ],
       "type": "string"
     },
-    "Measurement": {
-      "title": "Measurement",
+    "instrument_settings": {
+      "title": "instrument_settings",
       "type": "object",
       "properties": {
-        "scheme": {
-          "type": "string"
-        },
-        "omega": {
+        "incident_angle": {
           "description": "probe angle of incidence",
           "anyOf": [
             {
@@ -171,9 +200,28 @@
         }
       },
       "required": [
-        "scheme",
-        "omega",
+        "incident_angle",
         "wavelength"
+      ]
+    },
+    "Measurement": {
+      "title": "Measurement",
+      "type": "object",
+      "properties": {
+        "scheme": {
+          "enum": [
+            "angle- and energy-dispersive",
+            "angle-dispersive",
+            "energy-dispersive"
+          ]
+        },
+        "instrument_settings": {
+          "$ref": "#/definitions/instrument_settings"
+        }
+      },
+      "required": [
+        "scheme",
+        "instrument_settings"
       ]
     },
     "DataSource": {
@@ -181,22 +229,13 @@
       "type": "object",
       "properties": {
         "owner": {
-          "type": "string"
-        },
-        "facility": {
-          "type": "string"
-        },
-        "experimentID": {
-          "type": "string"
-        },
-        "experimentDate": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
+          "$ref": "#/definitions/owner"
         },
         "experiment": {
           "$ref": "#/definitions/Experiment"
+        },
+        "sample": {
+          "$ref": "#/definitions/Sample"
         },
         "measurement": {
           "$ref": "#/definitions/Measurement"
@@ -204,11 +243,8 @@
       },
       "required": [
         "owner",
-        "facility",
-        "experimentID",
-        "experimentDate",
-        "title",
         "experiment",
+        "sample",
         "measurement"
       ]
     }

--- a/metadata_schema/reduced_data_header_schema.yaml
+++ b/metadata_schema/reduced_data_header_schema.yaml
@@ -3,9 +3,9 @@ definitions:
     properties:
       affiliation:
         type: string
-      name:
+      computer:
         type: string
-      system:
+      name:
         type: string
       time:
         description: timestamp string, formatted as ISO 8601 datetime
@@ -15,71 +15,68 @@ definitions:
     - name
     - affiliation
     - time
-    - system
+    - computer
     title: Creator
     type: object
   DataSource:
     properties:
       experiment:
         $ref: '#/definitions/Experiment'
-      experimentDate:
-        type: string
-      experimentID:
-        type: string
-      facility:
-        type: string
       measurement:
         $ref: '#/definitions/Measurement'
       owner:
-        type: string
-      title:
-        type: string
+        $ref: '#/definitions/owner'
+      sample:
+        $ref: '#/definitions/Sample'
     required:
     - owner
-    - facility
-    - experimentID
-    - experimentDate
-    - title
     - experiment
+    - sample
     - measurement
     title: DataSource
     type: object
   Experiment:
     properties:
+      ID:
+        type: string
+      date:
+        description: timestamp string, formatted as ISO 8601 datetime
+        format: date-time
+        type: string
+      facility:
+        type: string
       instrument:
         type: string
       probe:
         enum:
-        - neutron
-        - xray
+        - neutrons
+        - x-rays
         type: string
-      sample:
-        $ref: '#/definitions/Sample'
+      title:
+        type: string
     required:
     - instrument
     - probe
-    - sample
     title: Experiment
     type: object
   Measurement:
     properties:
-      omega:
-        anyOf:
-        - $ref: '#/definitions/Value'
-        - $ref: '#/definitions/ValueRange'
-        description: probe angle of incidence
-      polarisation:
-        $ref: '#/definitions/Polarisation'
+      data_files:
+        items:
+          $ref: '#/definitions/data_file'
+        type: array
+      instrument_settings:
+        $ref: '#/definitions/instrument_settings'
       scheme:
+        enum:
+        - angle- and energy-dispersive
+        - angle-dispersive
+        - energy-dispersive
         type: string
-      wavelength:
-        anyOf:
-        - $ref: '#/definitions/Value'
-        - $ref: '#/definitions/ValueRange'
     required:
     - scheme
-    - omega
-    - wavelength
+    - instrument_settings
+    - data_files
     title: Measurement
     type: object
   Polarisation:
@@ -97,6 +94,17 @@ definitions:
     - ++
     title: Polarisation
     type: string
+  Reduction:
+    properties:
+      call:
+        type: string
+      software:
+        type: string
+    required:
+    - software
+    - call
+    title: Reduction
+    type: object
   Sample:
     properties:
       name:
@@ -118,6 +126,7 @@ definitions:
         type: string
     required:
     - magnitude
+    - unit
     title: Value
     type: object
   ValueRange:
@@ -134,15 +143,85 @@ definitions:
     required:
     - min
     - max
+    - unit
     title: ValueRange
     type: object
+  column:
+    description: Information on a data column.
+    properties:
+      dimension:
+        type: string
+      name:
+        description: The name of the column
+        type: string
+      unit:
+        description: SI unit string
+        enum:
+        - 1/angstrom
+        - 1/nm
+        type: string
+    required:
+    - name
+    - dimension
+    title: column
+    type: object
+  data_file:
+    properties:
+      created:
+        format: date-time
+        type: string
+      file:
+        type: string
+    required:
+    - file
+    - created
+    title: data_file
+    type: object
+  instrument_settings:
+    properties:
+      incident_angle:
+        anyOf:
+        - $ref: '#/definitions/Value'
+        - $ref: '#/definitions/ValueRange'
+      polarisation:
+        $ref: '#/definitions/Polarisation'
+      wavelength:
+        anyOf:
+        - $ref: '#/definitions/Value'
+        - $ref: '#/definitions/ValueRange'
+    required:
+    - incident_angle
+    - wavelength
+    title: instrument_settings
+    type: object
+  owner:
+    properties:
+      affiliation:
+        type: string
+      contact:
+        type: string
+      name:
+        type: string
+    required:
+    - name
+    - affiliation
+    - contact
+    title: owner
+    type: object
 properties:
+  columns:
+    items:
+      $ref: '#/definitions/column'
+    type: array
   creator:
     $ref: '#/definitions/Creator'
   data_source:
     $ref: '#/definitions/DataSource'
+  reduction:
+    $ref: '#/definitions/Reduction'
 required:
 - creator
 - data_source
+- columns
 title: ORSOHeader
 type: object


### PR DESCRIPTION
@bmaranville this updated schema is able to validate the test_example.ort at https://www.reflectometry.org/projects/file_formats/tasks/ws_2021-06_text/.

The yaml schema is not updated.

Note that there are several outstanding aspects that are missing from the schema:

- [x] measurement.data_files
- [ ] measurement.references
- [ ] columns
- [x] data_set
